### PR TITLE
Configure bot user for GitHub Actions releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,14 @@ jobs:
         with:
           app-id: 1053852
           private-key: ${{ secrets.AINOYA_BOT_PRIVATE_KEY }}
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
       - name: increment chrome extnsion manifest.json version
         run: |
           CURRENT_VERSION=$(jq -r '.version' public/manifest.json)


### PR DESCRIPTION
Add steps to configure the bot user for GitHub Actions releases, including retrieving the user ID and setting the appropriate git configuration.